### PR TITLE
feat: ignore league classic champions and reduce logging

### DIFF
--- a/data/src/main/java/com/spiderbiggen/randomchampionselector/data/champions/usecase/UpdateDataChampions.kt
+++ b/data/src/main/java/com/spiderbiggen/randomchampionselector/data/champions/usecase/UpdateDataChampions.kt
@@ -40,7 +40,12 @@ class UpdateDataChampions @Inject constructor(
 
             if (champions.isEmpty()) {
                 send(DownloadProgress.UpdateChampions)
-                champions = dDragon.getChampionList(lastVersion).map(championMapper::fromApi)
+                champions = dDragon.getChampionList(lastVersion).asSequence()
+                    // jade_ prefixed ids are for league classic and should be ignored until we
+                    // add support for separate champion lists
+                    .filter { !it.id.startsWith("jade_", ignoreCase = true) }
+                    .map(championMapper::fromApi)
+                    .toList()
                 championRepository.addChampions(champions)
             }
 

--- a/data/src/main/java/com/spiderbiggen/randomchampionselector/data/ddragon/ApiModule.kt
+++ b/data/src/main/java/com/spiderbiggen/randomchampionselector/data/ddragon/ApiModule.kt
@@ -19,7 +19,7 @@ class ApiModule {
         val httpClient = OkHttpClient.Builder()
         if (BuildConfig.DEBUG) {
             val logging = HttpLoggingInterceptor()
-            logging.level = HttpLoggingInterceptor.Level.BODY
+            logging.level = HttpLoggingInterceptor.Level.HEADERS
             httpClient.addInterceptor(logging)
         }
 


### PR DESCRIPTION

- Added functionality to ignore league classic champions in the dataset.
- Reduced okhttp logging by dropping the body from logged requests.
